### PR TITLE
Clean up scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_deploy:
   - gcloud --quiet config set project $PROJECT_ID
 deploy:
   provider: script
-  script: bash ./scripts/deploy.sh
+  script: ./scripts/deploy.sh
   on:
     branch: master

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The AFL data API for the Tipresias app and related data-science services
 
 ### Testing
 
-- `docker-compose run --rm app Rscript -e "devtools::test()"`
+- Run `./scripts/test.sh`
 
 ### Deploy
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ The AFL data API for the Tipresias app and related data-science services
 
 ### Testing
 
-- `docker-compose run --rm afl_data Rscript -e "devtools::test()"`
+- `docker-compose run --rm app Rscript -e "devtools::test()"`
 
 ### Deploy
 
-  - `gcloud builds submit --config cloudbuild.yaml ./afl_data`
-  - `gcloud beta run deploy $SERVICE_NAME --image gcr.io/$PROJECT_ID/afl_data --memory 2Gi`
+- Deploy app to Google Cloud:
+
+  - Merge a pull request into `master`
+  - Manually trigger a deploy:
+    - In the Travis dashboard, navigate to the tipresias repository.
+    - Under 'More Options', trigger a build on `master`.
+    - This will build the image, run tests, and deploy to Google Cloud.

--- a/afl_data/init.R
+++ b/afl_data/init.R
@@ -1,3 +1,22 @@
+# Suppressing all messages during installation, because R is excessive,
+# and it overloads the CI logs
+
+# store a copy of system2
+assign("system2.default", base::system2, baseenv())
+
+# create a quiet version of system2
+assign(
+  "system2.quiet",
+  function(...)system2.default(..., stdout = FALSE, stderr = FALSE),
+  baseenv()
+)
+
+# overwrite system2 with the quiet version
+assignInNamespace("system2", system2.quiet, "base")
+
+# this is now message-free:
+res <- eval(suppressMessages(install_github('ROAUth', 'duncantl')))
+
 install.packages("devtools")
 
 install.packages("BH")
@@ -18,3 +37,6 @@ devtools::install_git("git://github.com/tidyverse/tidyr.git")
 
 install.packages("roxygen2")
 install.packages("testthat")
+
+# reset system2 to its original version
+assignInNamespace("system2", system2.default, "base")

--- a/afl_data/init.R
+++ b/afl_data/init.R
@@ -1,42 +1,20 @@
-# Suppressing all messages during installation, because R is excessive,
-# and it overloads the CI logs
+install.packages("devtools", quiet = TRUE, verbose = FALSE)
 
-# store a copy of system2
-assign("system2.default", base::system2, baseenv())
-
-# create a quiet version of system2
-assign(
-  "system2.quiet",
-  function(...)system2.default(..., stdout = FALSE, stderr = FALSE),
-  baseenv()
-)
-
-# overwrite system2 with the quiet version
-assignInNamespace("system2", system2.quiet, "base")
-
-# this is now message-free:
-res <- eval(suppressMessages(install_github('ROAUth', 'duncantl')))
-
-install.packages("devtools")
-
-install.packages("BH")
-install.packages("dplyr")
-install.packages("plogr")
-install.packages("plumber")
-install.packages("progress")
-install.packages("purrr")
-install.packages("rvest")
-install.packages("stringr")
+install.packages("BH", quiet = TRUE, verbose = FALSE)
+install.packages("dplyr", quiet = TRUE, verbose = FALSE)
+install.packages("plogr", quiet = TRUE, verbose = FALSE)
+install.packages("plumber", quiet = TRUE, verbose = FALSE)
+install.packages("progress", quiet = TRUE, verbose = FALSE)
+install.packages("purrr", quiet = TRUE, verbose = FALSE)
+install.packages("rvest", quiet = TRUE, verbose = FALSE)
+install.packages("stringr", quiet = TRUE, verbose = FALSE)
 
 # Installing via git rather than github to avoid unauthenticated API
 # rate limits in CI
-devtools::install_git("git://github.com/jimmyday12/fitzRoy.git")
+devtools::install_git("git://github.com/jimmyday12/fitzRoy.git", quiet = TRUE)
 # Only using master-branch install to get new pivot_wider function.
 # Can switch back to CRAN once that gets released
-devtools::install_git("git://github.com/tidyverse/tidyr.git")
+devtools::install_git("git://github.com/tidyverse/tidyr.git", quiet = TRUE)
 
-install.packages("roxygen2")
-install.packages("testthat")
-
-# reset system2 to its original version
-assignInNamespace("system2", system2.default, "base")
+install.packages("roxygen2", quiet = TRUE, verbose = FALSE)
+install.packages("testthat", quiet = TRUE, verbose = FALSE)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,2 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
 gcloud builds submit --config cloudbuild.yaml ./afl_data
 gcloud beta run deploy ${SERVICE_NAME} --image gcr.io/${PROJECT_ID}/afl_data --memory 2Gi --region us-central1 --platform managed

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+docker-compose run --rm app Rscript -e "devtools::test()"


### PR DESCRIPTION
Mostly to reduce the number of messages logged when building the image since they overload the CI logs, but also some little improvements to the scripts.