### PR TITLE
Add filter to authorize API calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ PROJECT_ID=<name of the Google Cloud project>
 AFL_DATA_SERVICE=<hostname of the afl data service>
 SERVICE_NAME=<name of the afl data service>
 GOOGLE_APPLICATION_CREDENTIALS=<filepath of the Google Cloud credentials JSON>
+GCR_TOKEN=<authorization token for making calls to the afl data functions>

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -5,7 +5,20 @@ source(paste0(getwd(), "/R/fixtures.R"))
 source(paste0(getwd(), "/R/rosters.R"))
 
 FIRST_AFL_SEASON = "1897-01-01"
-END_OF_YEAR = paste0(lubridate::year(Sys.Date()), "12-31")
+END_OF_YEAR = paste0(lubridate::year(Sys.Date()), "-12-31")
+
+#* @filter checkAuth
+function(req, res){
+  if (
+    tolower(Sys.getenv("R_ENV")) == "production" &&
+    req$HTTP_AUTHORIZATION != paste0("Bearer ", Sys.getenv("GCR_TOKEN"))
+  ){
+    res$status <- 401
+    return(list(error="Not authorized"))
+  }
+
+  plumber::forward()
+}
 
 #' Return match results data
 #' @param fetch_data Whether to fetch fresh data from afltables.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     build: ./afl_data
     volumes:
       - ./afl_data:/app/afl_data
+    env_file:
+      .env
+    environment:
+      - R_ENV=development
     ports:
       - "8080:8080"
     stdin_open: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,4 +3,9 @@
 set -euo pipefail
 
 gcloud builds submit --config cloudbuild.yaml ./afl_data
-gcloud beta run deploy ${SERVICE_NAME} --image gcr.io/${PROJECT_ID}/afl_data --memory 2Gi --region us-central1 --platform managed
+gcloud beta run deploy ${SERVICE_NAME} \
+  --image gcr.io/${PROJECT_ID}/afl_data \
+  --memory 2Gi \
+  --region us-central1 \
+  --platform managed \
+  --update-env-vars GCR_TOKEN=${GCR_TOKEN},R_ENV=production


### PR DESCRIPTION
In production, the AFL data GC Run container will now check for an `Authorization` token.