### PR TITLE
Add future for async data processing

### DIFF
--- a/afl_data/DESCRIPTION
+++ b/afl_data/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
     dplyr,
     devtools,
     fitzRoy,
+    future,
     plogr,
     plumber,
     progress,

--- a/afl_data/R/betting-odds.R
+++ b/afl_data/R/betting-odds.R
@@ -1,3 +1,5 @@
+future::plan(future::multiprocess)
+
 FOOTY_WIRE_DOMAIN <- "https://www.footywire.com"
 BETTING_PATH <- "/afl/footy/afl_betting"
 BETTING_COL_NAMES <- c(
@@ -232,7 +234,8 @@ fetch_betting_odds <- function(start_date, end_date) {
 
   return(
     lubridate::year(start_date):lubridate::year(end_date) %>%
-      purrr::map(fetch_betting_odds_page) %>%
+      purrr::map(~ future::future({ fetch_betting_odds_page(.) })) %>%
+      future::values(.) %>%
       unlist(., recursive = FALSE) %>%
       normalize_row_length %>%
       unlist(.) %>%

--- a/afl_data/R/fixtures.R
+++ b/afl_data/R/fixtures.R
@@ -1,3 +1,5 @@
+future::plan(future::multiprocess)
+
 EARLIEST_VALID_SEASON = 2004
 
 #' Fetches fixture data via the fitzRoy package and filters by date range.
@@ -19,7 +21,8 @@ fetch_fixtures <- function(start_date, end_date) {
   }
 
   max(first_season, EARLIEST_VALID_SEASON):last_season %>%
-    purrr::map(fitzRoy::get_fixture) %>%
+    purrr::map(~ future::future({ fitzRoy::get_fixture(.) })) %>%
+    future::values(.) %>%
     dplyr::bind_rows(.) %>%
     dplyr::filter(., Date >= start_date & Date <= end_date) %>%
     dplyr::rename_all(

--- a/afl_data/init.R
+++ b/afl_data/init.R
@@ -2,6 +2,7 @@ install.packages("devtools", quiet = TRUE, verbose = FALSE)
 
 install.packages("BH", quiet = TRUE, verbose = FALSE)
 install.packages("dplyr", quiet = TRUE, verbose = FALSE)
+install.packages("future", quiet = TRUE, verbose = FALSE)
 install.packages("plogr", quiet = TRUE, verbose = FALSE)
 install.packages("plumber", quiet = TRUE, verbose = FALSE)
 install.packages("progress", quiet = TRUE, verbose = FALSE)


### PR DESCRIPTION
The big, slow data sets are pulled directly from `fitzRoy`, so there wasn't much to speed up, but I was able to reduce the run times of data fetching functions by roughly 2/3 by making the fetch-by-year part asynchronous.

I could probably extend the use of `future` in `betting-odds.R`, but I was getting errors, and the bulk of the improvement is in the I/O at the start of the pipeline, so good enough for now.