### PR TITLE
Install tidyr from CRAN instead of GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ before_deploy:
   - gcloud --quiet config set project $PROJECT_ID
 deploy:
   provider: script
-  script: ./scripts/deploy.sh
+  script: travis_wait 30 ./scripts/deploy.sh
   on:
     branch: master

--- a/afl_data/DESCRIPTION
+++ b/afl_data/DESCRIPTION
@@ -29,5 +29,4 @@ Suggests:
     testthat,
 Remotes:
     git@github.com:jimmyday12/fitzRoy.git,
-    git@github.com:tidyverse/tidyr.git
 RoxygenNote: 6.1.1

--- a/afl_data/init.R
+++ b/afl_data/init.R
@@ -9,6 +9,7 @@ install.packages("progress", quiet = TRUE, verbose = FALSE)
 install.packages("purrr", quiet = TRUE, verbose = FALSE)
 install.packages("rvest", quiet = TRUE, verbose = FALSE)
 install.packages("stringr", quiet = TRUE, verbose = FALSE)
+install.packages("tidyr", quiet = TRUE, verbose = FALSE)
 
 # Installing via git rather than github to avoid unauthenticated API
 # rate limits in CI
@@ -18,9 +19,6 @@ devtools::install_git(
   ref = "cf/fix-finals-round-numbers",
   quite = TRUE
 )
-# Only using master-branch install to get new pivot_wider function.
-# Can switch back to CRAN once that gets released
-devtools::install_git("git://github.com/tidyverse/tidyr.git", quiet = TRUE)
 
 install.packages("roxygen2", quiet = TRUE, verbose = FALSE)
 install.packages("testthat", quiet = TRUE, verbose = FALSE)


### PR DESCRIPTION
I saw that they released v1.0 with the 'pivot_' functions,
so I can go back to installing an official release.