### PR TITLE
Install fitzRoy from CRAN instead of GitHub

### DIFF
--- a/afl_data/DESCRIPTION
+++ b/afl_data/DESCRIPTION
@@ -29,4 +29,4 @@ Suggests:
     testthat,
 Remotes:
     git@github.com:jimmyday12/fitzRoy.git,
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.1

--- a/afl_data/init.R
+++ b/afl_data/init.R
@@ -13,11 +13,7 @@ install.packages("tidyr", quiet = TRUE, verbose = FALSE)
 
 # Installing via git rather than github to avoid unauthenticated API
 # rate limits in CI
-devtools::install_git(
-  "git://github.com/cfranklin11/fitzRoy.git",
-  quiet = TRUE,
-  ref = "cf/fix-betting-round"
-)
+devtools::install_git("git://github.com/jimmyday12/fitzRoy.git", quiet = TRUE)
 
 install.packages("roxygen2", quiet = TRUE, verbose = FALSE)
 install.packages("testthat", quiet = TRUE, verbose = FALSE)

--- a/afl_data/man/fetch_betting_odds.Rd
+++ b/afl_data/man/fetch_betting_odds.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/betting-odds.R
 \name{fetch_betting_odds}
 \alias{fetch_betting_odds}
-\title{Scrapes betting data from footywire, cleans it, and returns it
-as a dataframe.}
+\title{Fetchest betting data via the fitzRoy package and filters by date range.}
 \usage{
 fetch_betting_odds(start_date, end_date)
 }
@@ -13,6 +12,5 @@ fetch_betting_odds(start_date, end_date)
 \item{end_date}{Maximum match date for fetched data}
 }
 \description{
-Scrapes betting data from footywire, cleans it, and returns it
-as a dataframe.
+Fetchest betting data via the fitzRoy package and filters by date range.
 }


### PR DESCRIPTION
With the package's release on CRAN and some recently-merged fixes,
this is a better way to install fitzRoy.