### PR TITLE
Make sure to always close selenium server

### DIFF
--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -96,12 +96,13 @@ function(round_number = NULL) {
     )
   )
 
-  browser$open()
+  tryCatch({
+    browser$open()
 
-  browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH, "?GameWeeks=", round_number))
-  roster_data <- fetch_rosters(browser) %>% list(data = .)
-
-  browser$close()
-
-  roster_data
+    browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH, "?GameWeeks=", round_number))
+    roster_data <- fetch_rosters(browser) %>% list(data = .)
+  }, finally = {
+    browser$close()
+    browser$closeServer()
+  })
 }

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -6,6 +6,8 @@ source(paste0(getwd(), "/R/rosters.R"))
 
 FIRST_AFL_SEASON <- "1897-01-01"
 END_OF_YEAR <- paste0(lubridate::year(Sys.Date()), "-12-31")
+AFL_DOMAIN = "https://www.afl.com.au"
+TEAMS_PATH = "/matches/team-lineups"
 
 .is_production <- function() {
   PRODUCTION <- "production"
@@ -94,6 +96,12 @@ function(round_number = NULL) {
     )
   )
 
-  fetch_rosters(round_number, browser) %>%
-    list(data = .)
+  browser$open()
+
+  browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH, "?GameWeeks=", round_number))
+  roster_data <- fetch_rosters(browser) %>% list(data = .)
+
+  browser$close()
+
+  roster_data
 }

--- a/afl_data/man/fetch_rosters.Rd
+++ b/afl_data/man/fetch_rosters.Rd
@@ -5,11 +5,9 @@
 \title{Scrapes team roster data (i.e. which players are playing for each team) for
 a given round from afl.com.au, cleans it, and returns it as a dataframe.}
 \usage{
-fetch_rosters(round_number, browser)
+fetch_rosters(browser)
 }
 \arguments{
-\item{round_number}{Which round to get rosters for}
-
 \item{browser}{Selenium browser object for navigating to pages and crawling the DOM.}
 }
 \description{

--- a/afl_data/tests/testthat/test-rosters.R
+++ b/afl_data/tests/testthat/test-rosters.R
@@ -21,8 +21,11 @@ describe("fetch_rosters()", {
   browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH))
   roster_data <- fetch_rosters(browser)
   browser$close()
+  browser$closeServer()
 
   it("returns a data.frame or empty list", {
+    # Sometimes the roster page is blank, so we have to accept an empty list
+    # as a legitimate result
     if (length(roster_data) == 0) {
       expect_true("list" %in% class(roster_data))
     } else {

--- a/afl_data/tests/testthat/test-rosters.R
+++ b/afl_data/tests/testthat/test-rosters.R
@@ -17,19 +17,28 @@ describe("fetch_rosters()", {
   )
 
   # Fetching data takes awhile, so we do it once for all tests
-  roster_data <- fetch_rosters(NULL, browser)
+  browser$open()
+  browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH))
+  roster_data <- fetch_rosters(browser)
+  browser$close()
 
-  it("returns a data.frame", {
-    expect_true("data.frame" %in% class(roster_data))
+  it("returns a data.frame or empty list", {
+    if (length(roster_data) == 0) {
+      expect_true("list" %in% class(roster_data))
+    } else {
+      expect_true("data.frame" %in% class(roster_data))
+    }
   })
 
   it("has the correct data type for each column", {
-    expect_type(roster_data$player_name, "character")
-    expect_type(roster_data$playing_for, "character")
-    expect_type(roster_data$home_team, "character")
-    expect_type(roster_data$away_team, "character")
-    expect_type(roster_data$date, "double")
-    expect_type(roster_data$season, "double")
-    expect_type(roster_data$match_id, "character")
+    if (length(roster_data) > 0) {
+      expect_type(roster_data$player_name, "character")
+      expect_type(roster_data$playing_for, "character")
+      expect_type(roster_data$home_team, "character")
+      expect_type(roster_data$away_team, "character")
+      expect_type(roster_data$date, "double")
+      expect_type(roster_data$season, "double")
+      expect_type(roster_data$match_id, "character")
+    }
   })
 })


### PR DESCRIPTION
The bird-signs server memory usage keeps building up over time,
and I think we need to close the selenium server or it keeps
running, maybe leaving orphaned processes lying around.

Includes a little refactoring to make the `tryCatch` less cumbersome.