### PR TITLE
Enable Swagger on API.

### DIFF
--- a/afl_data/app.R
+++ b/afl_data/app.R
@@ -2,4 +2,4 @@ library("magrittr")
 
 port <- as.numeric(Sys.getenv("PORT", unset = "8080"))
 pr <- plumber::plumb("R/plumber.R")
-pr$run(host = "0.0.0.0", port = port)
+pr$run(host = "0.0.0.0", port = port, swagger = TRUE)


### PR DESCRIPTION
Great work on the API!

* Enable [Swagger](https://swagger.io/) on the plumber API.
* Swagger documentation available at `http://{host}:{port}/__swagger__/`

![image](https://user-images.githubusercontent.com/637298/85102174-6bd89680-b247-11ea-89bc-00a1068f6add.png)
