### PR TITLE
Add match_results endpoint

### DIFF
--- a/afl_data/R/matches.R
+++ b/afl_data/R/matches.R
@@ -3,8 +3,9 @@
 #' @param start_date Minimum match date for fetched data
 #' @param end_date Maximum match date for fetched data
 #' @export
-fetch_match_results <- function(start_date, end_date) {
+fetch_matches <- function(start_date, end_date) {
   fitzRoy::get_match_results() %>%
     dplyr::filter(., Date >= start_date & Date <= end_date) %>%
-    dplyr::rename_all(~ stringr::str_to_lower(.) %>% stringr::str_replace_all(., "\\.", "_"))
+    dplyr::rename_all(~ stringr::str_to_lower(.) %>%
+    stringr::str_replace_all(., "\\.", "_"))
 }

--- a/afl_data/R/matches.R
+++ b/afl_data/R/matches.R
@@ -9,3 +9,16 @@ fetch_matches <- function(start_date, end_date) {
     dplyr::rename_all(~ stringr::str_to_lower(.) %>%
     stringr::str_replace_all(., "\\.", "_"))
 }
+
+#' Fetch match results data from the Squiggle API.
+#' @importFrom magrittr %>%
+#' @param round_number Fetch matches from the given round
+#' @export
+fetch_match_results <- function(round_number) {
+  squiggle_api <- "https://api.squiggle.com.au"
+  year <- lubridate::now() %>% lubridate::year(.)
+  round_param <- ifelse(is.null(round_number), "", paste0(";round=", round_number))
+  url <- paste0(squiggle_api, "/?q=games;year=", year)
+
+  RCurl::getURL(url) %>% jsonlite::fromJSON(.) %>% .$games
+}

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -36,13 +36,13 @@ function() {
   "Welcome to BirdSigns, the AFL data service!"
 }
 
-#' Return match results data
+#' Return data for completed matches.
 #' @importFrom magrittr %>%
 #' @param start_date Minimum match date for fetched data
 #' @param end_date Maximum match date for fetched data
 #' @get /matches
 function(start_date = FIRST_AFL_SEASON, end_date = Sys.Date()) {
-  fetch_match_results(start_date, end_date) %>%
+  fetch_matches(start_date, end_date) %>%
     list(data = .)
 }
 

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -46,6 +46,15 @@ function(start_date = FIRST_AFL_SEASON, end_date = Sys.Date()) {
     list(data = .)
 }
 
+#' Return match results data without in-game stats. Current season only
+#' (for earlier seasons use the /matches endpoint).
+#' @importFrom magrittr %>%
+#' @param round_number Fetch matches from the given round
+#' @get /match_results
+function(round_number = NULL) {
+  fetch_match_results(round_number) %>% list(data = .)
+}
+
 #' Return player data
 #' @importFrom magrittr %>%
 #' @param start_date Minimum match date for fetched data


### PR DESCRIPTION
Since AFLTables updates their data once a week, we can't use
them to update results in the middle of a round, which means
the website UI is always out of date. Squiggle updates results
as they come in, and it's easier to use their API than scrape
a website.