### PR TITLE
Scrape Footywire for roster data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ venv.bak/
 packrat/lib*/
 *.Rcheck
 *_1.0.tar.gz
+.Rprofile
 
 # DB dumps
 *.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_script:
   - travis_wait 30 docker build --cache-from cfranklin11/tipresias_afl_data:latest -t cfranklin11/tipresias_afl_data:latest -f ./afl_data/ci.Dockerfile ./afl_data
 script:
   - docker-compose -f docker-compose.ci.yml up -d
-  - ./scripts/wait-for-it.sh localhost:4444 -- echo "Selenium ready"
   - ./scripts/wait-for-it.sh localhost:8050 -- echo "Splash ready"
   - docker-compose -f docker-compose.ci.yml run app Rscript -e "devtools::check(check_dir = '.')"
 before_deploy:

--- a/afl_data/DESCRIPTION
+++ b/afl_data/DESCRIPTION
@@ -15,8 +15,6 @@ Imports:
     fitzRoy,
     future,
     plumber,
-    RSelenium,
-    wdman,
     dplyr,
     here,
     jsonlite,

--- a/afl_data/DESCRIPTION
+++ b/afl_data/DESCRIPTION
@@ -22,10 +22,12 @@ Imports:
     magrittr,
     purrr,
     RCurl,
+    rvest,
     stringr,
     tibble,
     tidyr,
     tidyselect,
+    xml2,
 Suggests:
     roxygen2,
     testthat,

--- a/afl_data/Dockerfile
+++ b/afl_data/Dockerfile
@@ -1,11 +1,5 @@
 FROM rocker/tidyverse:4.0.2
 
-RUN apt-get update \
-  && apt-get -y --allow-downgrades --fix-broken install \
-  # The following needed for RSelenium
-  default-jre \
-  lbzip2
-
 WORKDIR /app/afl_data
 
 COPY init.R ./

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -122,39 +122,12 @@ function(start_date = FIRST_AFL_SEASON, end_date = END_OF_YEAR) {
     list(data = .)
 }
 
-#' Return team rosters for a given round (current season only)
+#' Return team rosters for the current round.
 #' @importFrom magrittr %>%
-#' @param round_number Fetch the rosters from this round. Note that missing param defaults to current round
+#' @param round_number Fetch the rosters from this round. Serves as a check
+#'  to make sure available roster data matches the requested round.
+#'  Leave blank to accept whatever the current round is.
 #' @get /rosters
 function(round_number = NULL) {
-  server_address <- "browser"
-  port <- 4444L
-
-  browser <- RSelenium::remoteDriver(
-    remoteServerAddr = server_address,
-    browser = 'chrome',
-    port = port,
-    extraCapabilities = list(
-      "goog:chromeOptions" = list(
-        args = list(
-          "--headless",
-          "--no-sandbox",
-          "--disable-gpu",
-          "--disable-dev-shm-usage",
-          "window-size=1024,768"
-        )
-      )
-    )
-  )
-
-  tryCatch({
-    browser$open()
-
-    query_param <- if (is.null(round_number)) "" else paste0("?GameWeeks=", round_number)
-    browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH, query_param))
-    roster_data <- fetch_rosters(browser) %>% list(data = .)
-  }, finally = {
-    browser$close()
-    browser$closeServer()
-  })
+  fetch_rosters(round_number) %>% list(data = .)
 }

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -150,7 +150,8 @@ function(round_number = NULL) {
   tryCatch({
     browser$open()
 
-    browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH, "?GameWeeks=", round_number))
+    query_param <- if (is.null(round_number)) "" else paste0("?GameWeeks=", round_number)
+    browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH, query_param))
     roster_data <- fetch_rosters(browser) %>% list(data = .)
   }, finally = {
     browser$close()

--- a/afl_data/R/rosters.R
+++ b/afl_data/R/rosters.R
@@ -150,10 +150,20 @@ fetch_rosters <- function(round_number) {
     return(list())
   }
 
-  .collect_match_elements(roster_page) %>%
+  fixture <- fitzRoy::get_fixture() %>%
+    dplyr::select(c('Date', 'Home.Team', 'Away.Team', 'Round')) %>%
+    dplyr::rename(
+      date = Date,
+      home_team = Home.Team,
+      away_team = Away.Team,
+      round_number = Round
+    )
+
+  rosters <- .collect_match_elements(roster_page) %>%
     purrr::imap(.parse_match_element) %>%
     dplyr::bind_rows(.) %>%
     .pivot_data_frame(.) %>%
     dplyr::mutate(., round_number = roster_round_number) %>%
-    .clean_data_frame(.)
+    .clean_data_frame(.) %>%
+    dplyr::inner_join(fixture, by = c('round_number', 'home_team', 'away_team'))
 }

--- a/afl_data/R/rosters.R
+++ b/afl_data/R/rosters.R
@@ -5,62 +5,39 @@ PLAYER_COL_NAMES <- c(
   "playing_for",
   "home_team",
   "away_team",
-  "date",
   "match_id"
 )
 
 HOME_AWAY <- c("home", "away")
 
 
-.parse_date_time <- function(date_time_string) {
-  lubridate::parse_date_time(
-    date_time_string, "%A %b %d %I:%M %p",
-    quiet = TRUE
-  ) %>%
-    # afl.com.au must detect timezone via the browser to display the match times
-    # in the user's local time, so they return UTC to our scraper.
-    # We convert everything to Melbourne time, because it's close enough,
-    # and I don't want to bother figuring out local time for all the venues,
-    # even though those are the timezones for raw match data.
-    lubridate::with_tz(., tzone = "Australia/Melbourne")
-}
-
-
 .clean_data_frame <- function(roster_df) {
   roster_df %>%
     dplyr::mutate_all(., as.character) %>%
-    tidyr::unite("date", c("date", "time"), remove = TRUE, sep = " ") %>%
     dplyr::mutate(
       .,
       player_name = stringr::str_extract(player_name, "[:alpha:]+(?:[:blank:][:alpha:]+)+"),
-      # We assume that we only scrape rosters for matches from this year,
-      # because any data from past matches are better retrieved from AFL Tables.
-      date = .parse_date_time(date),
       round_number = as.numeric(round_number),
-      season = lubridate::year(date)
+      season = lubridate::now() %>% lubridate::year(.)
     )
 }
 
 
-.get_round_number <- function(browser) {
-  roster_url <- browser$getCurrentUrl()
-  # For now, the easiest way to get the round number for the current page is
-  # from the URL parameter GameWeeks=<round number>, because the relevant
-  # elements are buried under a mountain non-semantic JavaScript rendering.
-  # We double extract in the hopes of making it somewhat more robust to potential
-  # changes in the URL structure.
-  roster_url %>%
-    stringr::str_extract(., "GameWeeks=\\d+") %>%
-    stringr::str_extract(., "\\d+")
+.get_round_number <- function(roster_page) {
+  roster_page %>%
+    rvest::html_node("h1.centertitle") %>%
+    rvest::html_text() %>%
+    stringr::str_match(., "Round (\\d+)") %>%
+    .[[2]] %>%
+    as.numeric(.)
 }
 
 
-.convert_to_data_frame <- function(matches) {
+.pivot_data_frame <- function(matches) {
   matches %>%
-  dplyr::bind_rows(.) %>%
   tidyr::pivot_wider(
     .,
-    id_cols = c(player_name, playing_for, date, time, match_id),
+    id_cols = c(player_name, playing_for, match_id),
     names_from = team_type,
     values_from = team
   ) %>%
@@ -69,70 +46,84 @@ HOME_AWAY <- c("home", "away")
 }
 
 
-.parse_team_data <- function(match_element, team_type) {
-  team_name <- match_element$findChildElement(
-    using = "css",
-    value = paste0(".team-lineups__team-name--", team_type)
-  )$getElementText() %>%
-    unlist
-
-  # For team name containers, they use "--home" and "--away"
-  # to differentiate between team types, but for player containers,
-  # they use "--home" and a blank suffix indicates 'away'
-  player_team_type <- if(team_type == "home") "--home" else ""
-
-  team_roster <- match_element$findChildElements(
-    using = "css",
-    value = paste0(".team-lineups__positions-players-container", player_team_type, " .team-lineups__player")
-  ) %>%
-    purrr::map(., ~ .x$getElementText()) %>%
-    unlist
-
-  tibble::tibble(
-    player_name = team_roster,
-    playing_for = rep_len(team_name, length(team_roster)),
-    team_type = rep_len(team_type, length(team_roster)),
-    round_number = rep_len(round_number, length(team_roster))
-  ) %>%
-    dplyr::mutate(team = playing_for)
+.fetch_player_name <- function(link_element) {
+  BASE_FOOTYWIRE_URL <- "https://www.footywire.com/afl/footy/"
+  link_element %>%
+    rvest::html_attr(., "href") %>%
+    paste0(BASE_FOOTYWIRE_URL, .) %>%
+    xml2::read_html(.) %>%
+    rvest::html_node(., "#playerProfileName") %>%
+    rvest::html_text(.)
 }
 
-.parse_match_elements <- function(cumulative_roster_data, match_element) {
-  DATE_CLASS <- "match-list__group-date"
-  TIME_CLASS <- "match-list-alt__header-time"
 
-  roster_data = rlang::duplicate(cumulative_roster_data)
+.parse_team_data <- function(match_tables) {
+  function(team_name, index) {
+    ROSTER_TABLE_INDEX <- 2
 
-  element_class <- match_element$getElementAttribute("class")
+    team_type <- HOME_AWAY[[index]]
+    # We need to reverse table order for "away", because tables are ordered:
+    # home interchange -> both rosters -> away interchange.
+    interchange_index <- if (team_type == "home") 1 else 3
+    row_modulo_remainder <- if (team_type == "home") 1 else 0
 
-  if (element_class == DATE_CLASS) {
-    roster_data$current_date <- match_element$getElementText() %>% unlist
-    return(roster_data)
+    interchange_players <- match_tables[[interchange_index]] %>%
+      rvest::html_nodes(., "a") %>%
+      # Only first four players listed are for interchange;
+      # others are emergencies, ins, or outs.
+      .[1:4] %>%
+      purrr::map(., .fetch_player_name) %>%
+      unlist(.)
+
+    roster_players <- match_tables[[ROSTER_TABLE_INDEX]] %>%
+      rvest::html_nodes("tr") %>%
+      purrr::imap(
+        ~ if (.y %% 2 == row_modulo_remainder) rvest::html_nodes(.x, "a") else NULL
+      ) %>%
+      unlist(., recursive = FALSE) %>%
+      purrr::map(., .fetch_player_name) %>%
+      unlist(.)
+
+    team_roster <- c(roster_players, interchange_players)
+
+    tibble::tibble(player_name = team_roster) %>%
+      dplyr::mutate(
+        playing_for = team_name,
+        team_type = team_type,
+        team = playing_for
+      )
   }
+}
 
-  if (element_class == TIME_CLASS) {
-    roster_data$current_time <- match_element$getElementText() %>% unlist
-    return(roster_data)
-  }
+.extract_team_names <- function(match_element) {
+  # Match label has the format <home team> v <away team> (<venue>)
+  UNTIL_VENUE_REGEX <- "[^(]+"
 
-  current_date <- cumulative_roster_data$current_date
-  current_time <- cumulative_roster_data$current_time
-  match_id <- cumulative_roster_data$match_id
+  match_element %>%
+      # There are multiple nodes that match this selector, but team names
+      # will always be in the first.
+      rvest::html_node(., '.tbtitle') %>%
+      rvest::html_text(.) %>%
+      stringr::str_extract(., UNTIL_VENUE_REGEX) %>%
+      stringr::str_split(., ' v ') %>%
+      unlist(.) %>%
+      stringr::str_trim(.)
+}
 
-  current_roster_data <- purrr::map(
-    HOME_AWAY, ~ .parse_team_data(match_element, .)
-  ) %>%
-    purrr::map(., ~ dplyr::mutate(
-      .x,
-      date = current_date,
-      time = current_time,
-      match_id = match_id
-    ))
+.parse_match_element <- function(match_element, index) {
+  match_tables <- match_element %>%
+    rvest::html_nodes('table') %>%
+    # Super janky, but only the table with summary statistics
+    # (and no player names) has cellpadding=0
+    purrr::discard(
+      ~ rvest::html_attr(., "cellpadding") %>% as.numeric(.) == 0
+    )
 
-  roster_data$roster_data <- c(roster_data$roster_data, current_roster_data)
-  roster_data$match_id <- match_id + 1
-
-  return(roster_data)
+  match_element %>%
+    .extract_team_names(.) %>%
+    purrr::imap(., .parse_team_data(match_tables)) %>%
+    dplyr::bind_rows(.) %>%
+    dplyr::mutate(match_id = index)
 }
 
 .collect_match_elements <- function(page) {
@@ -144,44 +135,6 @@ HOME_AWAY <- c("home", "away")
   match_roster_elements
 }
 
-.expand_roster_elements <- function(expandable_roster_elements) {
-  # We need to wait a second between clicking, because otherwise
-  # the browser gets confused and skips some of them.
-  click_expand_element <- function(el) {
-    el$clickElement()
-    Sys.sleep(1)
-  }
-
-  # We need to expand all of the hidden roster elements before collecting text,
-  # because Selenium can't interact with hidden elements,
-  # and sticking with RSelenium interactions rather than resorting
-  # to arbitrary JavaScript seems slightly less hacky.
-  expandable_roster_elements %>% purrr::map(click_expand_element)
-}
-
-.find_expandable_roster_elements <- function(browser) {
-  expandable_roster_elements <- list()
-  attempts <- 0
-
-  # afl.com.au is using some sort of javascript framework for rendering
-  # any data-based elements, and they lazy-load those elements
-  # (probably some sort of componentDidMount -> API call),
-  # which means that data-based elements load a second or two
-  # after the rest of the page, which means we need to retry
-  # accessing the relevant DOM elements a few times before they finally load.
-  while (length(expandable_roster_elements) == 0 && attempts < 5) {
-    Sys.sleep(1)
-
-    expandable_roster_elements <- browser$findElements(
-      using = "css",
-      value = ".team-lineups__expandable-trigger.js-expand-trigger.is-hidden"
-    )
-    attempts <- attempts + 1
-  }
-
-  expandable_roster_elements
-}
-
 #' Scrapes team roster data (i.e. which players are playing for each team) for
 #' a given round from afl.com.au, cleans it, and returns it as a dataframe.
 #' @importFrom magrittr %>%
@@ -189,21 +142,18 @@ HOME_AWAY <- c("home", "away")
 #' @export
 fetch_rosters <- function(round_number) {
   roster_page <- xml2::read_html(ROSTER_URL)
-  roster_round_number <- roster_page %>%
-    rvest::html_node("h1.centertitle") %>%
-    rvest::html_text() %>%
-    stringr::str_match(., "Round (\\d+)") %>%
-    .[[2]] %>%
-    as.numeric(.)
+  roster_round_number <- .get_round_number(roster_page)
 
+  # If we have mismatched round numbers, it means that the roster page
+  # hasn't been updated for the upcoming round yet
   if (!is.null(round_number) && roster_round_number != as.numeric(round_number)) {
     return(list())
   }
 
-  .collect_match_elements() %>%
-    purrr::reduce(.parse_match_elements, .init = list(match_id = 1)) %>%
-    .$roster_data %>%
-    .convert_to_data_frame(.) %>%
-    dplyr::mutate(., round_number = .get_round_number(browser)) %>%
+  .collect_match_elements(roster_page) %>%
+    purrr::imap(.parse_match_element) %>%
+    dplyr::bind_rows(.) %>%
+    .pivot_data_frame(.) %>%
+    dplyr::mutate(., round_number = roster_round_number) %>%
     .clean_data_frame(.)
 }

--- a/afl_data/ci.Dockerfile
+++ b/afl_data/ci.Dockerfile
@@ -4,12 +4,6 @@
 # the image from scratch every time.
 FROM rocker/tidyverse:4.0.2@sha256:cbc4ee809d594f0f6765be1d0fa046f48dfcda7340b5830473dd28fc71940c3c
 
-RUN apt-get update \
-  && apt-get -y --allow-downgrades --fix-broken install \
-  # The following needed for RSelenium
-  default-jre \
-  lbzip2
-
 WORKDIR /app/afl_data
 
 COPY init.R ./

--- a/afl_data/init.R
+++ b/afl_data/init.R
@@ -4,8 +4,6 @@ install.packages(
   c(
     "future",
     "plumber",
-    "wdman", # Required for RSelenium
-    "RSelenium",
     "here",
     "RCurl",
     quiet = TRUE,

--- a/afl_data/man/fetch_rosters.Rd
+++ b/afl_data/man/fetch_rosters.Rd
@@ -5,10 +5,10 @@
 \title{Scrapes team roster data (i.e. which players are playing for each team) for
 a given round from afl.com.au, cleans it, and returns it as a dataframe.}
 \usage{
-fetch_rosters(browser)
+fetch_rosters(round_number)
 }
 \arguments{
-\item{browser}{Selenium browser object for navigating to pages and crawling the DOM.}
+\item{round_number}{Fetch the rosters from this round. Serves as a check to make sure available roster data matches the requested round.}
 }
 \description{
 Scrapes team roster data (i.e. which players are playing for each team) for

--- a/afl_data/tests/testthat/test-betting-odds.R
+++ b/afl_data/tests/testthat/test-betting-odds.R
@@ -1,4 +1,12 @@
 describe("scrape_betting_odds()", {
+  skip_if(
+    Sys.getenv("CI") == "true",
+    message = paste(
+      "Runs fine on local, but keeps timing out in CI for some reason,",
+      "even with a longer timeout limit."
+    )
+  )
+
   splash_host <- "http://splash:8050"
 
   it("returns a data frame with the correct columns or empty list", {

--- a/afl_data/tests/testthat/test-rosters.R
+++ b/afl_data/tests/testthat/test-rosters.R
@@ -1,40 +1,17 @@
 describe("fetch_rosters()", {
-  browser <- RSelenium::remoteDriver(
-    remoteServerAddr = "browser",
-    browser = 'chrome',
-    port = 4444L,
-    extraCapabilities = list(
-      "goog:chromeOptions" = list(
-        args = list(
-          "--headless",
-          "--no-sandbox",
-          "--disable-gpu",
-          "--disable-dev-shm-usage",
-          "window-size=1024,768"
-        )
-      )
-    )
-  )
+  describe("with a non-matching round_number", {
+    nonexistent_round_number <- -1
+    roster_data <- fetch_rosters(nonexistent_round_number)
 
-  # Fetching data takes awhile, so we do it once for all tests
-  browser$open()
-  browser$navigate(paste0(AFL_DOMAIN, TEAMS_PATH))
-  roster_data <- fetch_rosters(browser)
-  browser$close()
-  browser$closeServer()
-
-  it("returns a data.frame or empty list", {
-    # Sometimes the roster page is blank, so we have to accept an empty list
-    # as a legitimate result
-    if (length(roster_data) == 0) {
-      expect_true("list" %in% class(roster_data))
-    } else {
-      expect_true("data.frame" %in% class(roster_data))
-    }
+    expect_true("list" %in% class(roster_data))
   })
 
-  it("has the correct data type for each column", {
-    if (length(roster_data) > 0) {
+  describe("with a NULL round_number", {
+    it("returns a data.frame", {
+      expect_true("data.frame" %in% class(roster_data))
+    })
+
+    it("has the correct data type for each column", {
       expect_type(roster_data$player_name, "character")
       expect_type(roster_data$playing_for, "character")
       expect_type(roster_data$home_team, "character")
@@ -43,6 +20,6 @@ describe("fetch_rosters()", {
       expect_type(roster_data$season, "double")
       expect_type(roster_data$match_id, "character")
       expect_type(roster_data$round_number, "double")
-    }
+    })
   })
 })

--- a/afl_data/tests/testthat/test-rosters.R
+++ b/afl_data/tests/testthat/test-rosters.R
@@ -3,10 +3,18 @@ describe("fetch_rosters()", {
     nonexistent_round_number <- -1
     roster_data <- fetch_rosters(nonexistent_round_number)
 
-    expect_true("list" %in% class(roster_data))
+    it("returns a list", {
+      expect_true("list" %in% class(roster_data))
+    })
+
+    it("is empty", {
+      expect_equal(length(roster_data), 0)
+    })
   })
 
   describe("with a NULL round_number", {
+    roster_data <- fetch_rosters(NULL)
+
     it("returns a data.frame", {
       expect_true("data.frame" %in% class(roster_data))
     })
@@ -16,7 +24,6 @@ describe("fetch_rosters()", {
       expect_type(roster_data$playing_for, "character")
       expect_type(roster_data$home_team, "character")
       expect_type(roster_data$away_team, "character")
-      expect_type(roster_data$date, "double")
       expect_type(roster_data$season, "double")
       expect_type(roster_data$match_id, "character")
       expect_type(roster_data$round_number, "double")

--- a/afl_data/tests/testthat/test-rosters.R
+++ b/afl_data/tests/testthat/test-rosters.R
@@ -24,6 +24,7 @@ describe("fetch_rosters()", {
       expect_type(roster_data$playing_for, "character")
       expect_type(roster_data$home_team, "character")
       expect_type(roster_data$away_team, "character")
+      expect_type(roster_data$date, "double")
       expect_type(roster_data$season, "double")
       expect_type(roster_data$match_id, "character")
       expect_type(roster_data$round_number, "double")

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,6 +4,7 @@ services:
     image: cfranklin11/tipresias_afl_data:latest
     environment:
       - R_ENV=development
+      - CI=true
     ports:
       - "8080:8080"
     command: Rscript app.R

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,17 +2,11 @@ version: "3.2"
 services:
   app:
     image: cfranklin11/tipresias_afl_data:latest
-    depends_on:
-      - browser
     environment:
       - R_ENV=development
     ports:
       - "8080:8080"
     command: Rscript app.R
-  browser:
-    image: selenium/standalone-chrome:3.141.59
-    ports:
-      - "4444:4444"
   splash:
     image: scrapinghub/splash
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,15 +2,9 @@ version: "3.2"
 services:
   app:
     image: cfranklin11/tipresias_afl_data:latest
-    depends_on:
-      - browser
     environment:
       - R_ENV=production
     env_file: .env
     ports:
       - "8080:8080"
     command: Rscript app.R
-  browser:
-    image: selenium/standalone-chrome:3.141.59
-    ports:
-      - "4444:4444"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     build: ./afl_data
     volumes:
       - ./afl_data:/app/afl_data
-    depends_on:
-      - browser
     env_file: .env
     environment:
       - R_ENV=development
@@ -14,10 +12,6 @@ services:
     stdin_open: true
     tty: true
     command: Rscript app.R
-  browser:
-    image: selenium/standalone-chrome:3.141.59
-    ports:
-      - "4444:4444"
   splash:
     image: scrapinghub/splash
     ports:


### PR DESCRIPTION
Removing Selenium will allow us to migrate from DigitalOcean to Google Cloud Run for the data service. It also simplifies the code a bit, as `rvest` is just easier to work with. The different naming conventions are a bit annoying (i.e. AFLTables and the official AFL site tend to abbreviate first names, but Footywire tends to display the full first name), but that can be handled via clever joins in the data pipeline.