### PR TITLE
Ignore updates to version 4 of R docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
     interval: monthly
     time: "19:00"
   open-pull-requests-limit: 10
+  ignore:
+    # Something about the newly-released version 4 of the R image breaks
+    # deployment to Google Cloud Run (it can't find executables
+    # for CMD/ENTRYPOINT).
+    # Hoping they fix it by the time they get to 4.1,
+    # because I couldn't figure it out
+    - dependency-name: rocker/tidyverse
+      versions: [4.0.x]


### PR DESCRIPTION
Per the comment, this version of the R image does something that
breaks Google Cloud Run deployment, even though it runs fine in
normal Docker container.