### PR TITLE
Convert alternative betting datetime to date

### DIFF
--- a/afl_data/R/betting-odds.R
+++ b/afl_data/R/betting-odds.R
@@ -122,6 +122,7 @@ scrape_betting_odds <- function(splash_host) {
   fixture_data <- .fetch_fixture_data()
 
   .append_match_cols_to_betting_data(betting_data, fixture_data) %>%
+    dplyr::mutate(Date = lubridate::as_date(Date)) %>%
     dplyr::rename_all(
       ~ stringr::str_to_lower(.) %>% stringr::str_replace_all(., "\\.", "_")
     )

--- a/afl_data/R/plumber.R
+++ b/afl_data/R/plumber.R
@@ -88,11 +88,6 @@ function(
 
   future_is_empty <- is.null(future_matches) || nrow(future_matches) == 0
 
-  print(is.null(future_matches))
-  print((nrow(future_matches) == 0))
-  print(future_is_empty)
-  print(as.logical(fallback_for_upcoming_round))
-
   if (future_is_empty && as.logical(fallback_for_upcoming_round)) {
     splash_host <- ifelse(
       .is_production(),


### PR DESCRIPTION
Trying to join the two betting data sets was raising errors due
to the Footywire 'date' being a date column and the Ladbrokes
'date' being a datetime column.