### PR TITLE
Downgrade R image and force use of earlier Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:4.0.3
+FROM rocker/tidyverse:4.0.0-ubuntu18.04
 
 WORKDIR /app
 


### PR DESCRIPTION
Apparently Ubuntu v20.04 doesn't work on Google Cloud Run for
some reason. The workarounds on Stack Overflow haven't worked
for me, and all images with R v4 use that version of Ubuntu
except this one special image that uses Ubuntu v18.04. At least
it deploys without error.