### PR TITLE
Manually set max season for betting data

### DIFF
--- a/afl_data/R/betting-odds.R
+++ b/afl_data/R/betting-odds.R
@@ -1,5 +1,8 @@
 source(here::here("R", "helpers.R"))
 
+# Footywire doesn't have any betting odds after the 2020 season
+MAX_SEASON <- 2020
+
 #' Fetches betting data via the fitzRoy package and filters by date range.
 #' @importFrom magrittr %>%
 #' @importFrom rlang .data
@@ -7,9 +10,11 @@ source(here::here("R", "helpers.R"))
 #' @param end_date Maximum match date for fetched data
 #' @export
 fetch_betting_odds <- function(start_date, end_date) {
+  end_season <- min(lubridate::year(end_date), MAX_SEASON)
+
   fitzRoy::fetch_betting_odds_footywire(
     start_season = lubridate::year(start_date),
-    end_season = lubridate::year(end_date)
+    end_season = end_season
   ) %>%
     dplyr::filter(.data$Date >= start_date & .data$Date <= end_date) %>%
     dplyr::rename_all(convert_to_snake_case)


### PR DESCRIPTION
Trying to fetch betting data that doesn't exist now raises an
error. This appears to be a regression in fitzRoy, but avoiding
trying to fetch for seasons that don't have data, and probably
never will, is a reasonable bandaid.